### PR TITLE
Upgrade CI

### DIFF
--- a/contracts/xtask/src/main.rs
+++ b/contracts/xtask/src/main.rs
@@ -71,7 +71,18 @@ fn main() -> Result<()> {
             )
             .run()?;
             node()?;
-            xshell::cmd!(sh, "cargo t").run()?;
+            let output = xshell::cmd!(sh, "git diff --name-only master...HEAD").read()?;
+            for line in output.lines() {
+                let parts: Vec<&str> = line.split('/').collect();
+                if let Some(idx) = parts.iter().position(|&x| x == "contracts") {
+                    if let Some(directory) = parts.get(idx + 1) {
+                        if !directory.contains('.') {
+                            xshell::cmd!(sh, "cargo test --manifest-path {directory}/Cargo.toml")
+                                .run()?;
+                        }
+                    }
+                }
+            }
             docs()?;
         }
         "docs" => docs()?,


### PR DESCRIPTION
The change involves adding an additional processing step before executing the cargo test command. In the first version of the code, only the `cargo t` command was executed, whereas in the second version:
1. First, the `git diff --name-only master...HEAD` command is executed to obtain a list of changed files between the master branch and the current HEAD branch.
2. Then, each line of output from this command is processed. In this case, each line is split into parts using the `/` delimiter, and the second part after the "_contracts_" string is extracted.
3. If this second part does not contain a `.`, it is considered a directory (assuming contracts is the beginning of the directory path). In this case, the `cargo test --manifest-path {directory}/Cargo.toml` command is executed, where `{directory}` is replaced with the directory name.

Thus, the second version of the code dynamically analyzes the changed files in the project directory and runs tests only for those directories containing changes and not being files.